### PR TITLE
Remove the default service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,15 @@ This modules creates components needed to be able to expose your application(s) 
 
 When included and configured this module will:
 - create public ALB
-- create a HTTPS Listener on default ALB with default rule
-- the default rule will be either 404 service (microservice which returns 404 responses to all requests) or haproxy proxy which will proxy all requests to configured `BACKEND_IP`
-- output ALB Listener ARN and DNS Record for the ALB - you'll need both to be able to integrate your services with the ALB
+- create a HTTPS Listener on default ALB with default target group
+- output default target group ARN
 
 The final product is an AWS ALB which you can configure your services to be attached.
 
 Module Input Variables
 ----------------------
 
-- `team` - (string) - **REQUIRED** - Name of Team deploying the ALB - will affect ALBs name
-- `env` - (string) - **REQUIRED** - Environment deployed to
-- `component` - (string) - **REQUIRED** - component name
-- `platform_config` - (map) **REQUIRED** - Mergermarket Platform config dictionary (see tests for example one)
-- `alb_domain` - (string) - **REQUIRED** DNS Domain name to be used as a entry to the service (Fastly will be configured to use it)
-- `bare_redirect_domain_name` - (string) - If set, a service will be created in live to redirect this bare domain to the prefixed version - for example you might set this value to `my-site.com` in order to redirect users to `www.my-site.com` (default `""`, i.e. will not be used)
-- `backend_ip` - (string) - If set to IP - it'll cause a proxying service to be deployed that will proxy - by default - all requests to given IP; this IP should be / can be different per environment and configured via `config` mechanism.  Default `404` - will deploy service that - by default - returns 404s to all requests
-- `backend_port` - (string) - Port number the requests to the backend will be sent to (default `80`)
-- `ssl_cert_check` - (bool) - Check the backend cert is valid - warning disabling this makes you vulnerable to a man-in-the-middle imporsonating your backend (default `true`)
-- `ssl_cert_hostname` - (bool) - The hostname to validate the certificate presented by the backend against (default `""`)
-- `health_check_interval` - (string) - (default "5") The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds.
-- `health_check_path` - (string) - The destination for the health check request (default `"/internal/healthcheck"`)
-- `health_check_timeout` - (string) - The amount of time, in seconds, during which no response means a failed health check (default `"4"`)
-- `health_check_healthy_threshold` - (string) - The number of consecutive health checks successes required before considering an unhealthy target healthy (default `"2"`)
-- `health_check_unhealthy_threshold` - (string) - The number of consecutive health check failures required before considering the target unhealthy (default `"2"`)
-- `health_check_matcher` - (string) - The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299") (default `"200-299"`) 
+See `/variables.tf`.
 
 Usage
 -----
@@ -58,18 +42,13 @@ module "router" {
   source = "github.com/mergermarket/tf_router"
 
   alb_domain      = "domain.com"
-  team            = "humptydumptyteam"
   env             = "ci"
   component       = "wall"
   platform_config = "${var.platform_config}"
-
-  # optional
-  # backend_ip              = "1.1.1.1"
-  bare_redirect_domain_name = "externaldomain.com"
 }
 ```
 
 Outputs
 -------
-- `alb_dns_name` - The DNS name of the load balancer
-- `alb_listener_arn` - The ARN of the load balancer
+
+See `/outputs.tf`.

--- a/main.tf
+++ b/main.tf
@@ -1,52 +1,8 @@
-module "404_container_definition" {
-  source = "github.com/mergermarket/tf_ecs_container_definition"
-
-  name           = "404"
-  image          = "mergermarket/404"
-  cpu            = "16"
-  memory         = "16"
-  container_port = "80"
-}
-
-module "haproxy_proxy_container_definition" {
-  source = "github.com/mergermarket/tf_ecs_container_definition"
-
-  name           = "haproxy"
-  image          = "mergermarket/haproxy-proxy"
-  cpu            = "16"
-  memory         = "32"
-  container_port = "8000"
-
-  container_env = {
-    BACKEND_IP   = "${var.backend_ip}"
-    BACKEND_PORT = "${var.backend_port}"
-  }
-}
-
-module "default_backend_task_definition" {
-  source = "github.com/mergermarket/tf_ecs_task_definition"
-
-  family                = "${format("%s-%s", var.env, var.component)}-default"
-  container_definitions = ["${var.backend_ip == "404" ? module.404_container_definition.rendered : module.haproxy_proxy_container_definition.rendered}"]
-}
-
 module "default_backend_ecs_service" {
-  source = "github.com/mergermarket/tf_load_balanced_ecs_service"
+  source = "modules/deprecated"
 
-  name                             = "${replace(replace(format("%s-%s", var.env, var.component), "/(.{0,24}).*/", "$1"), "/^-+|-+$/", "")}-default"
-  container_name                   = "${var.backend_ip == "404" ? "404" : "haproxy"}"
-  container_port                   = "${var.backend_ip == "404" ? "80" : "8000"}"
-  vpc_id                           = "${var.platform_config["vpc"]}"
-  task_definition                  = "${module.default_backend_task_definition.arn}"
-  desired_count                    = "${var.env == "live" ? 2 : 1}"
-  alb_listener_arn                 = "${module.alb.alb_listener_arn}"
-  alb_arn                          = "${module.alb.alb_arn}"
-  health_check_path                = "${var.health_check_path}"
-  health_check_interval            = "${var.health_check_interval}"
-  health_check_timeout             = "${var.health_check_timeout}"
-  health_check_healthy_threshold   = "${var.health_check_healthy_threshold}"
-  health_check_unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
-  health_check_matcher             = "${var.health_check_matcher}"
+  name   = "${replace(replace(format("%s-%s", var.env, var.component), "/(.{0,24}).*/", "$1"), "/^-+|-+$/", "")}-default"
+  vpc_id = "${var.platform_config["vpc"]}"
 }
 
 module "alb" {
@@ -58,7 +14,7 @@ module "alb" {
   extra_security_groups    = ["${var.platform_config["ecs_cluster.default.client_security_group"]}"]
   internal                 = "false"
   certificate_domain_name  = "${format("*.%s%s", var.env != "live" ? "dev." : "", var.alb_domain)}"
-  default_target_group_arn = "${module.default_backend_ecs_service.target_group_arn}"
+  default_target_group_arn = "${module.aws_alb_target_group.default_target_group.arn}"
   access_logs_bucket       = "${lookup(var.platform_config, "elb_access_logs_bucket", "")}"
   access_logs_enabled      = "${"${lookup(var.platform_config, "elb_access_logs_bucket", "")}" == "" ? false : true}"
 
@@ -66,6 +22,25 @@ module "alb" {
     component   = "${var.component}"
     environment = "${var.env}"
     team        = "${var.team}"
+  }
+}
+
+resource "aws_alb_target_group" "default_target_group" {
+  name = "${replace(replace("${var.env}-default-${var.component}", "/(.{0,32}).*/", "$1"), "/^-+|-+$/", "")}"
+
+  # port will be set dynamically, but for some reason AWS requires a value
+  port                 = "31337"
+  protocol             = "HTTP"
+  vpc_id               = "${var.platform_config["vpc"]}"
+  deregistration_delay = "${var.default_target_group_deregistration_delay}"
+
+  health_check {
+    interval            = "${var.default_target_group_health_check_interval}"
+    path                = "${var.default_target_group_health_check_path}"
+    timeout             = "${var.default_target_group_health_check_timeout}"
+    healthy_threshold   = "${var.default_target_group_health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.default_target_group_health_check_unhealthy_threshold}"
+    matcher             = "${var.default_target_group_health_check_matcher}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ module "alb" {
   extra_security_groups    = ["${var.platform_config["ecs_cluster.default.client_security_group"]}"]
   internal                 = "false"
   certificate_domain_name  = "${format("*.%s%s", var.env != "live" ? "dev." : "", var.alb_domain)}"
-  default_target_group_arn = "${module.aws_alb_target_group.default_target_group.arn}"
+  default_target_group_arn = "${aws_alb_target_group.default_target_group.arn}"
   access_logs_bucket       = "${lookup(var.platform_config, "elb_access_logs_bucket", "")}"
   access_logs_enabled      = "${"${lookup(var.platform_config, "elb_access_logs_bucket", "")}" == "" ? false : true}"
 

--- a/modules/deprecated/main.tf
+++ b/modules/deprecated/main.tf
@@ -1,0 +1,26 @@
+variable "name" {}
+
+variable "vpc_id" {}
+
+resource "aws_alb_target_group" "target_group" {
+  name = "${replace(replace(var.name, "/(.{0,32}).*/", "$1"), "/^-+|-+$/", "")}"
+
+  # port will be set dynamically, but for some reason AWS requires a value
+  port                 = "31337"
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc_id}"
+  deregistration_delay = "10"
+
+  health_check {
+    interval            = "5"
+    path                = "/internal/healthcheck"
+    timeout             = "4"
+    healthy_threshold   = "2"
+    unhealthy_threshold = "2"
+    matcher             = "200-299"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,0 @@
-output "alb_dns_name" {
-  value = "${module.alb.alb_dns_name}"
-}
-
-output "alb_listener_arn" {
-  value = "${module.alb.alb_listener_arn}"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "default_target_group_arn" {
+  value = "${module.aws_alb_target_group.default_target_group.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "default_target_group_arn" {
-  value = "${module.aws_alb_target_group.default_target_group.arn}"
+  value = "${aws_alb_target_group.default_target_group.arn}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -19,22 +19,6 @@ module "router" {
   env             = "${var.env}"
   component       = "${var.component}"
   platform_config = "${var.platform_config}"
-
-  # optional
-  # backend_ip = "1.1.1.1"
-}
-
-module "router_timeouts" {
-  source = "../.."
-
-  alb_domain            = "${var.alb_domain}"
-  team                  = "${var.team}"
-  env                   = "${var.env}"
-  component             = "${var.component}"
-  platform_config       = "${var.platform_config}"
-  connect_timeout       = "${var.connect_timeout}"
-  first_byte_timeout    = "${var.first_byte_timeout}"
-  between_bytes_timeout = "${var.between_bytes_timeout}"
 }
 
 # variables
@@ -47,28 +31,6 @@ variable "env" {}
 
 variable "component" {}
 
-variable "backend_ip" {
-  default = "404"
-}
-
 variable "platform_config" {
   type = "map"
-}
-
-variable "connect_timeout" {
-  type        = "string"
-  description = ""
-  default     = 5000
-}
-
-variable "first_byte_timeout" {
-  type        = "string"
-  description = ""
-  default     = 60000
-}
-
-variable "between_bytes_timeout" {
-  type        = "string"
-  description = ""
-  default     = 30000
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,85 +23,44 @@ variable "alb_domain" {
 }
 
 # optional
-variable "bare_redirect_domain_name" {
+
+variable "default_target_group_deregistration_delay" {
+  description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds."
   type        = "string"
-  default     = ""
-  description = "If set then an additional service will be created to redirect the zone apex (bare domain) to the domain - i.e. add the www."
+  default     = "10"
 }
 
-variable "backend_ip" {
-  description = "Backend to route all requests by default to; default: 404 (see README)"
-  type        = "string"
-  default     = "404"
-}
-
-variable "backend_port" {
-  description = "Backend port to use; default: 80"
-  type        = "string"
-  default     = "80"
-}
-
-variable "ssl_cert_check" {
-  description = "Check the backend cert is valid"
-  type        = "string"
-  default     = "true"
-}
-
-variable "ssl_cert_hostname" {
-  description = "The hostname to validate the certificate presented by the backend against"
-  type        = "string"
-  default     = ""
-}
-
-variable "connect_timeout" {
-  type        = "string"
-  description = ""
-  default     = 5000
-}
-
-variable "first_byte_timeout" {
-  type        = "string"
-  description = ""
-  default     = 60000
-}
-
-variable "between_bytes_timeout" {
-  type        = "string"
-  description = ""
-  default     = 30000
-}
-
-variable "health_check_interval" {
+variable "default_target_group_health_check_interval" {
   description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds."
   type        = "string"
   default     = "5"
 }
 
-variable "health_check_path" {
+variable "default_target_group_health_check_path" {
   description = "The destination for the health check request."
   type        = "string"
   default     = "/internal/healthcheck"
 }
 
-variable "health_check_timeout" {
+variable "default_target_group_health_check_timeout" {
   description = "The amount of time, in seconds, during which no response means a failed health check."
   type        = "string"
   default     = "4"
 }
 
-variable "health_check_healthy_threshold" {
+variable "default_target_group_health_check_healthy_threshold" {
   description = "The number of consecutive health checks successes required before considering an unhealthy target healthy."
   type        = "string"
   default     = "2"
 }
 
-variable "health_check_unhealthy_threshold" {
+variable "default_target_group_health_check_unhealthy_threshold" {
   description = "The number of consecutive health check failures required before considering the target unhealthy."
   type        = "string"
   default     = "2"
 }
 
-variable "health_check_matcher" {
+variable "default_target_group_health_check_matcher" {
   description = "The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
   type        = "string"
   default     = "200-299"


### PR DESCRIPTION
This change removes the default service as we have with other routers,
moving the default target group into the main.tf file. Some time after
this has merged (i.e. when it has been applied to all components that
use it), we should be able to remove the modules/deprecated folder (the
default target group must be replaced before we can delete the old target
group).